### PR TITLE
Add Depfile for Pip Install

### DIFF
--- a/cmake/morpheus_utils/python/pip_gen_depfile.py
+++ b/cmake/morpheus_utils/python/pip_gen_depfile.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+from pip._internal.commands.show import search_packages_info
+
+
+def gen_dep_file(pkg_name: str, input_file: str, output_file: str):
+
+    package_generator = search_packages_info([pkg_name])
+
+    for pkg_info in package_generator:
+
+        if (pkg_info.name == pkg_name):
+
+            joined_files = " ".join([os.path.join(pkg_info.location, f) for f in pkg_info.files])
+
+            # Create the output lines
+            lines = [f"{input_file}: {joined_files}"]
+
+            # Write the depfile
+            with open(output_file, "w") as f:
+                f.writelines(lines)
+
+            break
+
+
+if (__name__ == "__main__"):
+    parser = argparse.ArgumentParser(description='Process some integers.')
+
+    parser.add_argument("--pkg_name", type=str, required=True, help='an integer for the accumulator')
+    parser.add_argument('--input_file', type=str, required=True, help='sum the integers (default: find the max)')
+    parser.add_argument('--output_file', type=str, help='sum the integers (default: find the max)')
+
+    args = parser.parse_args()
+
+    if (args.output_file is None):
+        args.output_file = args.input_file + ".d"
+
+    gen_dep_file(pkg_name=args.pkg_name, input_file=args.input_file, output_file=args.output_file)

--- a/cmake/morpheus_utils/python/python_module_tools.cmake
+++ b/cmake/morpheus_utils/python/python_module_tools.cmake
@@ -361,13 +361,15 @@ function(morpheus_utils_build_python_package PACKAGE_NAME)
     message(STATUS "Automatically installing Python package '${PACKAGE_NAME}' into current python environment. This may overwrite any existing library with the same name")
 
     # Now actually install the package
-    set(install_stamp ${sources_binary_dir}/${PYTHON_ACTIVE_PACKAGE_NAME}-install.stamp)
+    set(install_stamp_depfile ${install_stamp}.d)
 
     add_custom_command(
       OUTPUT ${install_stamp}
       COMMAND ${_pip_command}
       COMMAND ${CMAKE_COMMAND} -E touch ${install_stamp}
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pip_gen_depfile.py --pkg_name ${PACKAGE_NAME} --input_file ${install_stamp} --output_file ${install_stamp_depfile}
       DEPENDS ${PYTHON_ACTIVE_PACKAGE_NAME}-outputs
+      DEPFILE ${install_stamp_depfile}
       COMMENT "Installing ${PACKAGE_NAME} python package"
     )
 
@@ -558,7 +560,7 @@ macro(__create_python_library MODULE_NAME)
     add_custom_command(
       OUTPUT  ${module_binary_stub_file}
       COMMAND ${Python3_EXECUTABLE} -m pybind11_stubgen ${TARGET_NAME} --no-setup-py --log-level WARN -o ./ --root-module-suffix \"\"
-      DEPENDS ${PYTHON_ACTIVE_PACKAGE_NAME}-modules
+      DEPENDS ${PYTHON_ACTIVE_PACKAGE_NAME}-modules $<TARGET_OBJECTS:${TARGET_NAME}>
       COMMENT "Building stub for python module ${TARGET_NAME}..."
       WORKING_DIRECTORY ${module_root_binary_dir}
     )


### PR DESCRIPTION
When using the python_module_tools.cmake functions inside of a devcontainer, the package gets uninstalled every time VS Code or the container is restarted. To fix this, this PR generates a depfile which lists the installed pip files inside of the conda environment as dependencies on the build.

What happens now is when the build is rerun in a fresh container, even if the build folder is mounted from an earlier container, the python package is correctly installed.

This also adds a dependency to the stub file generation to rebuild the stubs anytime a python module is recompiled (but not relinked)