### PR TITLE
Fix Message Context in Macros

### DIFF
--- a/cmake/morpheus_utils/environment_config/rapids_cmake/register_api.cmake
+++ b/cmake/morpheus_utils/environment_config/rapids_cmake/register_api.cmake
@@ -54,6 +54,8 @@ macro(morpheus_utils_initialize_cuda_arch project_name)
 
   # Initialize CUDA architectures
   rapids_cuda_init_architectures(${project_name})
+
+  list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 endmacro()
 
 function(morpheus_utils_initialize_package_manager


### PR DESCRIPTION
There was a single macro which pushed a message context and forgot to pop it. Unlike functions, the context needs to be popped otherwise the calling function will be modified.