### PR TITLE
Improve Handling of RAPIDS Versions

### DIFF
--- a/cmake/morpheus_utils/environment_config/rapids_cmake/ensure_rapids_cmake_init.cmake
+++ b/cmake/morpheus_utils/environment_config/rapids_cmake/ensure_rapids_cmake_init.cmake
@@ -17,19 +17,24 @@
 
 include_guard(GLOBAL)
 
-set(RAPIDS_CMAKE_VERSION "22.10" CACHE STRING "Version of rapids-cmake to use")
+# Ensure we have MORPHEUS_UTILS_RAPIDS_VERSION set
+include("${CMAKE_CURRENT_LIST_DIR}/rapids_version.cmake")
+
+set(RAPIDS_CMAKE_VERSION "\${MORPHEUS_UTILS_RAPIDS_VERSION}" CACHE STRING "Version of rapids-cmake to use")
+
+eval_rapids_version(${RAPIDS_CMAKE_VERSION} _rapids_cmake_version)
 
 # Download and load the repo according to the rapids-cmake instructions if it does not exist
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS_CMAKE.cmake)
-  message(STATUS "Downloading RAPIDS CMake Version: ${RAPIDS_CMAKE_VERSION}")
+if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS_CMAKE_${_rapids_cmake_version}.cmake)
+  message(STATUS "Downloading RAPIDS CMake Version: ${_rapids_cmake_version}")
   file(
-      DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_CMAKE_VERSION}/RAPIDS.cmake
-      ${CMAKE_BINARY_DIR}/RAPIDS_CMAKE.cmake
+      DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${_rapids_cmake_version}/RAPIDS.cmake
+      ${CMAKE_BINARY_DIR}/RAPIDS_CMAKE_${_rapids_cmake_version}.cmake
   )
 endif()
 
 # Now load the file
-include(${CMAKE_BINARY_DIR}/RAPIDS_CMAKE.cmake)
+include(${CMAKE_BINARY_DIR}/RAPIDS_CMAKE_${_rapids_cmake_version}.cmake)
 
 # Load Rapids Cmake packages
 include(rapids-cmake)

--- a/cmake/morpheus_utils/environment_config/rapids_cmake/rapids_version.cmake
+++ b/cmake/morpheus_utils/environment_config/rapids_cmake/rapids_version.cmake
@@ -17,12 +17,24 @@
 
 include_guard(GLOBAL)
 
-macro(morpheus_utils_package_config_ensure_rapids_cpm_init)
-  if (MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE)
-    message(STATUS "MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE:${MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE}"
-        ", is set and will be used.")
-    rapids_cpm_init(OVERRIDE "${MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE}")
-  else()
-    rapids_cpm_init()
-  endif()
-endmacro()
+if (DEFINED MORPHEUS_UTILS_RAPIDS_VERSION)
+   message(STATUS "Setting MORPHEUS_UTILS_RAPIDS_VERSION. Prev value: '${MORPHEUS_UTILS_RAPIDS_VERSION}'")
+else()
+   message(STATUS "Setting MORPHEUS_UTILS_RAPIDS_VERSION.")
+endif()
+
+# This variable must be set early since many functions use it
+set(MORPHEUS_UTILS_RAPIDS_VERSION 22.10 CACHE STRING "The default version to use for RAPIDS libraries unless otherwise specified.")
+
+function(eval_rapids_version input_value output_var_name)
+
+   set(version "${input_value}")
+
+   # Allow setting version to a variable. If so, evaluate that here. Allows for dependent versions, i.e. RMM_VERSION=${MORPHEUS_UTILS_RAPIDS_VERSION}
+   if("${version}" MATCHES [=[^\${(.+)}$]=])
+      set(version "${${CMAKE_MATCH_1}}")
+   endif()
+
+   set(${output_var_name} "${version}" PARENT_SCOPE)
+
+endfunction()

--- a/cmake/morpheus_utils/environment_config/rapids_cmake/register_api.cmake
+++ b/cmake/morpheus_utils/environment_config/rapids_cmake/register_api.cmake
@@ -16,31 +16,7 @@
 # Ensure this is only run once
 include_guard(GLOBAL)
 
-macro(morpheus_utils_ensure_rapids_cpm_init)
-  set(prefix F_ARGV)
-  set(options "")
-  set(singleValueArgs RAPIDS_CMAKE_VERSION)
-  set(multiValueArgs "")
-
-  include(CMakeParseArguments)
-  cmake_parse_arguments(${prefix}
-      "${options}"
-      "${singleValueArgs}"
-      "${multiValueArgs}"
-      ${ARGN})
-
-  if (F_ARGV_RAPIDS_CMAKE_VERSION)
-    set(rapids_cmake_version "${F_ARGV_RAPIDS_CMAKE_VERSION}")
-  elseif(MORPHEUS_UTILS_OVERRIDE_RAPIDS_CMAKE_VERSION)
-    set(rapids_cmake_version "${MORPHEUS_UTILS_OVERRIDE_RAPIDS_CMAKE_VERSION}")
-  else()
-    set(rapids_cmake_version "22.10")
-  endif()
-
-  morpheus_utils_initialize_rapids_cmake(rapids_cmake_version)
-endmacro()
-
-function(morpheus_utils_initialize_rapids_cmake RAPIDS_VERSION_VAR_NAME)
+function(morpheus_utils_ensure_rapids_cpm_init)
   include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/ensure_rapids_cmake_init.cmake")
 endfunction()
 

--- a/cmake/morpheus_utils/package_config/cudf/Configure_cudf.cmake
+++ b/cmake/morpheus_utils/package_config/cudf/Configure_cudf.cmake
@@ -20,7 +20,11 @@ function(morpheus_utils_configure_cudf)
   list(APPEND CMAKE_MESSAGE_CONTEXT "cudf")
 
   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
-  set(CUDF_VERSION "22.08" CACHE STRING "Which version of cuDF to use")
+
+  set(CUDF_VERSION "\${MORPHEUS_UTILS_RAPIDS_VERSION}" CACHE STRING "Which version of cuDF to use. Defaults to \${MORPHEUS_UTILS_RAPIDS_VERSION}")
+
+  # Convert to a useable version
+  eval_rapids_version(${CUDF_VERSION} CUDF_VERSION)
 
   rapids_cpm_find(cudf ${CUDF_VERSION}
       GLOBAL_TARGETS

--- a/cmake/morpheus_utils/package_config/ensure_cpm_init.cmake
+++ b/cmake/morpheus_utils/package_config/ensure_cpm_init.cmake
@@ -18,7 +18,7 @@
 include_guard(GLOBAL)
 
 # Make sure RAPIDS CMake has been loaded
-# include(${CMAKE_CURRENT_LIST_DIR}/../environment_config/rapids_cmake/ensure_rapids_cmake_init.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../environment_config/rapids_cmake/ensure_rapids_cmake_init.cmake)
 
 if (MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE)
   message(STATUS "MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE:${MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE}"

--- a/cmake/morpheus_utils/package_config/ensure_cpm_init.cmake
+++ b/cmake/morpheus_utils/package_config/ensure_cpm_init.cmake
@@ -17,6 +17,13 @@
 
 include_guard(GLOBAL)
 
-include(${CMAKE_CURRENT_LIST_DIR}/package_config_macros.cmake)
+# Make sure RAPIDS CMake has been loaded
+# include(${CMAKE_CURRENT_LIST_DIR}/../environment_config/rapids_cmake/ensure_rapids_cmake_init.cmake)
 
-morpheus_utils_package_config_ensure_rapids_cpm_init()
+if (MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE)
+  message(STATUS "MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE:${MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE}"
+      ", is set and will be used.")
+  rapids_cpm_init(OVERRIDE "${MORPHEUS_UTILS_RAPIDS_CPM_INIT_OVERRIDE}")
+else()
+  rapids_cpm_init()
+endif()

--- a/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
+++ b/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
@@ -21,11 +21,6 @@ function(morpheus_utils_configure_mrc)
   list(APPEND CMAKE_MESSAGE_CONTEXT "mrc")
 
   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
-  if ((NOT MORPHEUS_UTILS_RAPIDS_VERSION) OR ("${MORPHEUS_UTILS_RAPIDS_VERSION}" STREQUAL ""))
-    set(MRC_RMM_VERSION "22.10")
-  else()
-    set(MRC_RMM_VERSION "${MORPHEUS_UTILS_RAPIDS_VERSION}")
-  endif()
 
   set(MRC_VERSION 23.01 CACHE STRING "Which version of MRC to use")
 
@@ -57,4 +52,3 @@ function(morpheus_utils_configure_mrc)
 
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 endfunction()
-

--- a/cmake/morpheus_utils/package_config/rmm/Configure_rmm.cmake
+++ b/cmake/morpheus_utils/package_config/rmm/Configure_rmm.cmake
@@ -21,11 +21,10 @@ function(morpheus_utils_configure_rmm)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rmm")
 
   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
-  set(RMM_VERSION "22.10" CACHE STRING "Version of RMM to use.")
 
-  if ("${RMM_VERSION}" MATCHES [=[^\${(.+)}$]=])
-    set(RMM_VERSION "${${CMAKE_MATCH_1}}")
-  endif()
+  set(RMM_VERSION "\${MORPHEUS_UTILS_RAPIDS_VERSION}" CACHE STRING "Version of RMM to use.")
+
+  eval_rapids_version(${RMM_VERSION} RMM_VERSION)
 
   rapids_cpm_find(rmm ${RMM_VERSION}
     GLOBAL_TARGETS

--- a/cmake/morpheus_utils/python/python_module_tools.cmake
+++ b/cmake/morpheus_utils/python/python_module_tools.cmake
@@ -361,6 +361,7 @@ function(morpheus_utils_build_python_package PACKAGE_NAME)
     message(STATUS "Automatically installing Python package '${PACKAGE_NAME}' into current python environment. This may overwrite any existing library with the same name")
 
     # Now actually install the package
+    set(install_stamp ${sources_binary_dir}/${PYTHON_ACTIVE_PACKAGE_NAME}-install.stamp)
     set(install_stamp_depfile ${install_stamp}.d)
 
     add_custom_command(


### PR DESCRIPTION
When upgrading Morpheus to use cuDF 22.10, several issues popped up regarding how rapids versions are handled. This improves the functionality.