### PR TITLE
Fixing some issues after moving the ci/runner scripts to utilities

### DIFF
--- a/ci/runner/README.md
+++ b/ci/runner/README.md
@@ -17,13 +17,24 @@
 
 The `Dockerfile` in this directory defines the images used by the CI runner not for the repo itself.
 
+# Setup
+All commands should be run from the repository root. Change directories to the repo root before continuing:
+
+```bash
+cd $(git rev-parse --show-toplevel)
+
+# Or if you are in a submodule
+cd $(git rev-parse --show-superproject-working-tree)
+```
+
 # Building CI images
 The `Dockerfile` defines two targets: `base` and `driver`. The `driver` target includes the Nvidia driver needed to build MRC on a machine without access to a GPU.
 
 To build the images from the root of the repo run:
 ```bash
-SKIP_PUSH=1 external/utilities/ci/runner/build_and_push.sh
+SKIP_PUSH=1 ./external/utilities/ci/runner/build_and_push.sh ./ci/runner
 ```
+Where `./ci/runner` is the path to the directory containing the CI Runner's Dockerfile. Usually this is at `${REPO_ROOT}/ci/runner`.
 
 # Build and push CI images
 This will require being a member of the `Morpheus Early Access CI` group in [NGC](https://catalog.ngc.nvidia.com) and logging into the `nvcr.io` registry prior to running.
@@ -41,3 +52,5 @@ Update `.github/workflows/pull_request.yml` changing these two lines with the ne
       container: nvcr.io/ea-nvidia-morpheus/morpheus:${repo_name}-ci-driver-221128
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:${repo_name}-ci-base-221128
 ```
+
+Where the final 6 digits of the tag represent the current year, month, and day in the form `YYMMDD`.

--- a/ci/runner/build_and_push.sh
+++ b/ci/runner/build_and_push.sh
@@ -14,11 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Get the repo name from git. Either Morpheus or MRC
+REPO_NAME=$(basename -s .git `git config --get remote.origin.url`)
+
+# Convert it to lower
+REPO_NAME=$(echo "${REPO_NAME}" | tr '[:upper:]' '[:lower:]')
+
 DOCKER_TARGET=${DOCKER_TARGET:-"base" "driver"}
 DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 DOCKER_REGISTRY_SERVER=${DOCKER_REGISTRY_SERVER:-"nvcr.io"}
 DOCKER_REGISTRY_PATH=${DOCKER_REGISTRY_PATH:-"/ea-nvidia-morpheus/morpheus"}
-DOCKER_TAG_PREFIX=${DOCKER_TAG_PREFIX:-"mrc-ci"}
+DOCKER_TAG_PREFIX=${DOCKER_TAG_PREFIX:-"${REPO_NAME}-ci"}
 DOCKER_TAG_POSTFIX=${DOCKER_TAG_POSTFIX:-"$(date +'%y%m%d')"}
 DOCKER_EXTRA_ARGS=${DOCKER_EXTRA_ARGS:-""}
 
@@ -26,6 +32,9 @@ SKIP_BUILD=${SKIP_BUILD:-""}
 SKIP_PUSH=${SKIP_PUSH:-""}
 
 set -e
+
+# Get the runner context from the user supplied argument or default to ci/runner
+RUNNER_CONTEXT=${1:-./ci/runner}
 
 function get_image_full_name() {
    echo "${DOCKER_REGISTRY_SERVER}${DOCKER_REGISTRY_PATH}:${DOCKER_TAG_PREFIX}-${build_target}-${DOCKER_TAG_POSTFIX}"
@@ -35,7 +44,7 @@ if [[ "${SKIP_BUILD}" == "" ]]; then
     for build_target in ${DOCKER_TARGET[@]}; do
         FULL_NAME=$(get_image_full_name)
         echo "Building target \"${build_target}\" as ${FULL_NAME}";
-        docker buildx build --network=host ${DOCKER_EXTRA_ARGS} --target ${build_target} -t ${FULL_NAME} -f ./Dockerfile .
+        docker buildx build --network=host ${DOCKER_EXTRA_ARGS} --target ${build_target} -t ${FULL_NAME} -f ${RUNNER_CONTEXT}/Dockerfile .
     done
 fi
 

--- a/ci/runner/build_and_push.sh
+++ b/ci/runner/build_and_push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ REPO_NAME=$(basename -s .git `git config --get remote.origin.url`)
 # Convert it to lower
 REPO_NAME=$(echo "${REPO_NAME}" | tr '[:upper:]' '[:lower:]')
 
-DOCKER_TARGET=${DOCKER_TARGET:-"base" "driver"}
+DOCKER_TARGET=${DOCKER_TARGET:-"driver" "test"}
 DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 DOCKER_REGISTRY_SERVER=${DOCKER_REGISTRY_SERVER:-"nvcr.io"}
 DOCKER_REGISTRY_PATH=${DOCKER_REGISTRY_PATH:-"/ea-nvidia-morpheus/morpheus"}

--- a/cmake/morpheus_utils/environment_config/rapids_cmake/rapids_version.cmake
+++ b/cmake/morpheus_utils/environment_config/rapids_cmake/rapids_version.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# SPDX-FileCopyrightText: Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,6 @@
 #=============================================================================
 
 include_guard(GLOBAL)
-
-if (DEFINED MORPHEUS_UTILS_RAPIDS_VERSION)
-   message(STATUS "Setting MORPHEUS_UTILS_RAPIDS_VERSION. Prev value: '${MORPHEUS_UTILS_RAPIDS_VERSION}'")
-else()
-   message(STATUS "Setting MORPHEUS_UTILS_RAPIDS_VERSION.")
-endif()
 
 # This variable must be set early since many functions use it
 set(MORPHEUS_UTILS_RAPIDS_VERSION 22.10 CACHE STRING "The default version to use for RAPIDS libraries unless otherwise specified.")


### PR DESCRIPTION
When running the CI runner instructions, some were out of date after the move to utilities.