### PR TITLE
Remove the Numpy Dependency from CMake and Revert Boost Config

### DIFF
--- a/cmake/morpheus_utils/package_config/boost/Configure_boost.cmake
+++ b/cmake/morpheus_utils/package_config/boost/Configure_boost.cmake
@@ -49,56 +49,61 @@ include_guard(GLOBAL)
 #   )
 # endfunction()
 
-# # This function uses boost-cmake (https://github.com/Orphis/boost-cmake) to
-# # configure boost. Not always up to date.
-# function(morpheus_utils_configure_boost_boost_cmake)
-#   list(APPEND CMAKE_MESSAGE_CONTEXT "boost")
-
-#   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
-#   set(BOOST_VERSION "1.74.0" CACHE STRING "Version of boost to use")
-
-#   set(Boost_USE_DEBUG_LIBS OFF)  # ignore debug libs
-
-#   rapids_cpm_find(Boost ${BOOST_VERSION}
-#     GLOBAL_TARGETS
-#       Boost::context Boost::fiber Boost::hana Boost::filesystem Boost::system
-#     BUILD_EXPORT_SET
-#       ${PROJECT_NAME}-core-exports
-#     INSTALL_EXPORT_SET
-#       ${PROJECT_NAME}-core-exports
-#     CPM_ARGS
-#       GIT_REPOSITORY          https://github.com/Orphis/boost-cmake.git
-#       GIT_TAG                 "7f97a08b64bd5d2e53e932ddf80c40544cf45edf"
-#       GIT_SHALLOW             TRUE
-#       OPTIONS                 "BUILD_TESTING OFF"
-#       FIND_PACKAGE_ARGUMENTS  "COMPONENTS context fiber filesystem system"
-#   )
-
-#   if (NOT Boost_ADDED)
-#     # Now add it to the list of packages to install
-#     rapids_export_package(INSTALL Boost
-#       ${PROJECT_NAME}-core-exports
-#       GLOBAL_TARGETS Boost::context Boost::fiber Boost::hana Boost::filesystem Boost::system
-#     )
-
-#     # Overwrite the default package contents
-#     file(WRITE "${CMAKE_BINARY_DIR}/rapids-cmake/${PROJECT_NAME}-core-exports/install/package_Boost.cmake" "find_dependency(Boost REQUIRED COMPONENTS context fiber filesystem system)")
-#   endif()
-# endfunction()
-
+# This function uses boost-cmake (https://github.com/Orphis/boost-cmake) to
+# configure boost. Not always up to date.
 function(morpheus_utils_configure_boost)
   list(APPEND CMAKE_MESSAGE_CONTEXT "boost")
 
+  include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
   set(BOOST_VERSION "1.74.0" CACHE STRING "Version of boost to use")
 
-  rapids_find_package(Boost ${BOOST_VERSION} REQUIRED
+  set(Boost_USE_DEBUG_LIBS OFF)  # ignore debug libs
+
+  rapids_cpm_find(Boost ${BOOST_VERSION}
     GLOBAL_TARGETS
       Boost::context Boost::fiber Boost::hana Boost::filesystem Boost::system
     BUILD_EXPORT_SET
       ${PROJECT_NAME}-core-exports
     INSTALL_EXPORT_SET
       ${PROJECT_NAME}-core-exports
+    CPM_ARGS
+      GIT_REPOSITORY          https://github.com/Orphis/boost-cmake.git
+      GIT_TAG                 "7f97a08b64bd5d2e53e932ddf80c40544cf45edf"
+      GIT_SHALLOW             TRUE
+      OPTIONS                 "BUILD_TESTING OFF"
+      FIND_PACKAGE_ARGUMENTS  "COMPONENTS context fiber filesystem system"
   )
 
-  list(POP_BACK CMAKE_MESSAGE_CONTEXT)
+  if (NOT Boost_ADDED)
+    # Now add it to the list of packages to install
+    rapids_export_package(INSTALL Boost
+      ${PROJECT_NAME}-core-exports
+      GLOBAL_TARGETS Boost::context Boost::fiber Boost::hana Boost::filesystem Boost::system
+    )
+
+    # Overwrite the default package contents
+    file(WRITE "${CMAKE_BINARY_DIR}/rapids-cmake/${PROJECT_NAME}-core-exports/install/package_Boost.cmake" "find_dependency(Boost REQUIRED COMPONENTS context fiber filesystem system)")
+  endif()
 endfunction()
+
+# function(morpheus_utils_configure_boost)
+#   list(APPEND CMAKE_MESSAGE_CONTEXT "boost")
+
+#   set(BOOST_VERSION "1.74.0" CACHE STRING "Version of boost to use")
+
+#   rapids_find_package(Boost
+#     GLOBAL_TARGETS
+#       Boost::context Boost::fiber Boost::hana Boost::filesystem Boost::system
+#     BUILD_EXPORT_SET
+#       ${PROJECT_NAME}-core-exports
+#     INSTALL_EXPORT_SET
+#       ${PROJECT_NAME}-core-exports
+#     FIND_ARGS
+#       ${BOOST_VERSION} REQUIRED COMPONENTS context fiber filesystem system
+#   )
+
+#   # Overwrite the default package contents
+#   file(WRITE "${CMAKE_BINARY_DIR}/rapids-cmake/${PROJECT_NAME}-core-exports/install/package_Boost.cmake" "find_dependency(Boost REQUIRED COMPONENTS context fiber filesystem system)")
+
+#   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
+# endfunction()

--- a/cmake/morpheus_utils/package_config/ucx/Configure_ucx.cmake
+++ b/cmake/morpheus_utils/package_config/ucx/Configure_ucx.cmake
@@ -17,188 +17,188 @@
 
 include_guard(GLOBAL)
 
-# function(morpheus_utils_configure_ucx)
-#   list(APPEND CMAKE_MESSAGE_CONTEXT "ucx")
-
-#   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
-#   set(UCX_VERSION "1.13" CACHE STRING "Version of ucx to use")
-
-#   # Try to find UCX and download from source if not found
-#   rapids_cpm_find(ucx ${UCX_VERSION}
-#     GLOBAL_TARGETS
-#       ucx ucx::ucp ucx::uct ucx_ucx ucx::ucp ucx::uct ucx::ucx
-#     BUILD_EXPORT_SET
-#       ${PROJECT_NAME}-core-exports
-#     INSTALL_EXPORT_SET
-#       ${PROJECT_NAME}-core-exports
-#     CPM_ARGS
-#       GIT_REPOSITORY          https://github.com/openucx/ucx.git
-#       GIT_TAG                 "v${UCX_VERSION}"
-#       DOWNLOAD_ONLY           TRUE
-#   )
-
-#   if (ucx_ADDED)
-#     # If we got here, UCX wasnt found. Add custom targets to build from source.
-#     message(STATUS "UCX Not Found. Building from source.")
-
-#     # Location where all files will be temp installed
-#     set(ucx_INSTALL_DIR ${ucx_BINARY_DIR}/install)
-
-#     # Because libtool shows an error when calling `make install
-#     # prefix=<INSTALL_DIR>`. We have to use DESTDIR instead. Make a symbolic
-#     # link to prevent very long names in the include paths
-#     set(ucx_DEST_DIR ${ucx_BINARY_DIR}/install_dest)
-
-#     # Ensure the output exists
-#     file(MAKE_DIRECTORY ${ucx_DEST_DIR}/${CMAKE_INSTALL_PREFIX})
-#     file(CREATE_LINK ${ucx_DEST_DIR}/${CMAKE_INSTALL_PREFIX} ${ucx_INSTALL_DIR} SYMBOLIC)
-#     file(MAKE_DIRECTORY ${ucx_BINARY_DIR}/install)
-#     file(MAKE_DIRECTORY ${ucx_INSTALL_DIR}/include)
-
-#     # file(MAKE_DIRECTORY ${ucx_BINARY_DIR}/src)
-
-#     include(ExternalProject)
-
-#     string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UC)
-
-#     # Get the Compiler settings to forward onto autoconf
-#     set(COMPILER_SETTINGS
-#       "CXX=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}"
-#       "CPP=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER} -E"
-#       "CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}"
-#       "AR=${CMAKE_C_COMPILER_AR}"
-#       "RANLIB=${CMAKE_C_COMPILER_RANLIB}"
-#       "NM=${CMAKE_NM}"
-#       "STRIP=${CMAKE_STRIP}"
-#       "CFLAGS=${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}"
-#       "CPPFLAGS=${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}"
-#       "CXXFLAGS=${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UC}}"
-#       "LDFLAGS=${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_${BUILD_TYPE_UC}}"
-#     )
-
-#     # Use BUILD_IN_SOURCE because UCX cant do out of source builds and CMake sucks at change directory
-#     ExternalProject_Add(ucx
-#       PREFIX            ${ucx_BINARY_DIR}
-#       SOURCE_DIR        ${ucx_BINARY_DIR}
-#       INSTALL_DIR       ${ucx_INSTALL_DIR}
-#       # Copy from CPM cache into the build tree
-#       DOWNLOAD_COMMAND  ${CMAKE_COMMAND} -E copy_directory ${ucx_SOURCE_DIR} ${ucx_BINARY_DIR}
-#       # The io_demo fails to build in out of source builds. So remove that from
-#       # the Makefile (wish we could just disable all test/examples/apps) as a
-#       # part of the download command
-#       PATCH_COMMAND     git checkout -- . &&
-#                         git apply --whitespace=fix ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches/disable_tools_and_java_binds.patch
-#       # Note, we set SED and GREP here since they can be hard coded in the conda libtoolize
-#       CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env SED=sed GREP=grep <SOURCE_DIR>/autogen.sh
-#                 COMMAND <SOURCE_DIR>/contrib/configure-release ${COMPILER_SETTINGS} --prefix=${CMAKE_INSTALL_PREFIX}
-#                         --enable-mt --without-rdmacm --disable-gtest --disable-examples
-#       BUILD_COMMAND     make -j
-#       BUILD_IN_SOURCE   TRUE
-#       BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/libuct.a
-#                         <INSTALL_DIR>/lib/libucp.a
-#                         <INSTALL_DIR>/lib/libucs.a
-#                         <INSTALL_DIR>/lib/libucm.a
-#       INSTALL_COMMAND   make DESTDIR=${ucx_DEST_DIR} install
-#       LOG_CONFIGURE     TRUE
-#       LOG_BUILD         TRUE
-#       LOG_INSTALL       TRUE
-#       # Add a target for configuring to allow for style checks on source code
-#       STEP_TARGETS      install
-#     )
-
-#     # Install only the headers
-#     install(
-#       DIRECTORY ${ucx_INSTALL_DIR}/include
-#       TYPE INCLUDE
-#     )
-
-#     # TODO: We support components in the custom build branch but not when UCX is found via find_package.
-#     # UCT Library
-#     add_library(ucx::uct STATIC IMPORTED GLOBAL)
-#     set_target_properties(ucx::uct PROPERTIES
-#       INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ucx_INSTALL_DIR}/include>;$<INSTALL_INTERFACE:include>"
-#       INTERFACE_POSITION_INDEPENDENT_CODE "ON"
-#     )
-#     set_property(TARGET ucx::uct APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-#     set_target_properties(ucx::uct PROPERTIES
-#       IMPORTED_LOCATION_RELEASE "${ucx_INSTALL_DIR}/lib/libuct.a"
-#       IMPORTED_SONAME_RELEASE "libuct.a"
-#     )
-#     add_dependencies(ucx::uct ucx)
-
-#     # UCP Library
-#     add_library(ucx::ucp STATIC IMPORTED GLOBAL)
-#     set_target_properties(ucx::ucp PROPERTIES
-#       INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ucx_INSTALL_DIR}/include>;$<INSTALL_INTERFACE:include>"
-#       INTERFACE_POSITION_INDEPENDENT_CODE "ON"
-#     )
-#     set_property(TARGET ucx::ucp APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-#     set_target_properties(ucx::ucp PROPERTIES
-#       IMPORTED_LOCATION_RELEASE "${ucx_INSTALL_DIR}/lib/libucp.a"
-#       IMPORTED_SONAME_RELEASE "libucp.a"
-#     )
-#     add_dependencies(ucx::ucp ucx)
-
-#     # UCS Library
-#     add_library(ucx::ucs STATIC IMPORTED GLOBAL)
-#     set_target_properties(ucx::ucs PROPERTIES
-#       INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ucx_INSTALL_DIR}/include>;$<INSTALL_INTERFACE:include>"
-#       INTERFACE_POSITION_INDEPENDENT_CODE "ON"
-#     )
-#     set_property(TARGET ucx::ucs APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-#     set_target_properties(ucx::ucs PROPERTIES
-#       IMPORTED_LOCATION_RELEASE "${ucx_INSTALL_DIR}/lib/libucs.a"
-#       IMPORTED_SONAME_RELEASE "libucs.a"
-#     )
-#     add_dependencies(ucx::ucs ucx)
-
-#     # UCM Library
-#     add_library(ucx::ucm STATIC IMPORTED GLOBAL)
-#     set_target_properties(ucx::ucm PROPERTIES
-#       INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ucx_INSTALL_DIR}/include>;$<INSTALL_INTERFACE:include>"
-#       INTERFACE_POSITION_INDEPENDENT_CODE "ON"
-#     )
-#     set_property(TARGET ucx::ucm APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-#     set_target_properties(ucx::ucm PROPERTIES
-#       IMPORTED_LOCATION_RELEASE "${ucx_INSTALL_DIR}/lib/libucm.a"
-#       IMPORTED_SONAME_RELEASE "libucm.a"
-#     )
-#     add_dependencies(ucx::ucm ucx)
-
-#     # Combined ucx::ucx target
-#     add_library(ucx::ucx INTERFACE IMPORTED)
-#     set_target_properties(ucx::ucx PROPERTIES
-#       INTERFACE_LINK_LIBRARIES "ucx::uct;ucx::ucp;ucx::ucs;ucx::ucm"
-#     )
-
-#     # Finally, add this to the style check dependencies
-#     add_dependencies(${PROJECT_NAME}_style_checks ucx-install)
-#   else()
-#     # Found installed UCX. Make sure to call rapids_export_package without a version.
-#     # Otherwise CMake fails with trying to add the dependency twice
-#     rapids_export_package(
-#       INSTALL ucx ${PROJECT_NAME}-core-exports
-#       GLOBAL_TARGETS ucx ucx::ucp ucx::uct ucx_ucx ucx::ucp ucx::uct ucx::ucx
-#     )
-
-#   endif()
-
-#   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
-# endfunction()
-
 function(morpheus_utils_configure_ucx)
   list(APPEND CMAKE_MESSAGE_CONTEXT "ucx")
 
+  include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
   set(UCX_VERSION "1.13" CACHE STRING "Version of ucx to use")
 
-  rapids_find_package(ucx ${UCX_VERSION} REQUIRED
+  # Try to find UCX and download from source if not found
+  rapids_cpm_find(ucx ${UCX_VERSION}
     GLOBAL_TARGETS
       ucx ucx::ucp ucx::uct ucx_ucx ucx::ucp ucx::uct ucx::ucx
     BUILD_EXPORT_SET
       ${PROJECT_NAME}-core-exports
     INSTALL_EXPORT_SET
       ${PROJECT_NAME}-core-exports
+    CPM_ARGS
+      GIT_REPOSITORY          https://github.com/openucx/ucx.git
+      GIT_TAG                 "v${UCX_VERSION}"
+      DOWNLOAD_ONLY           TRUE
   )
+
+  if (ucx_ADDED)
+    # If we got here, UCX wasnt found. Add custom targets to build from source.
+    message(STATUS "UCX Not Found. Building from source.")
+
+    # Location where all files will be temp installed
+    set(ucx_INSTALL_DIR ${ucx_BINARY_DIR}/install)
+
+    # Because libtool shows an error when calling `make install
+    # prefix=<INSTALL_DIR>`. We have to use DESTDIR instead. Make a symbolic
+    # link to prevent very long names in the include paths
+    set(ucx_DEST_DIR ${ucx_BINARY_DIR}/install_dest)
+
+    # Ensure the output exists
+    file(MAKE_DIRECTORY ${ucx_DEST_DIR}/${CMAKE_INSTALL_PREFIX})
+    file(CREATE_LINK ${ucx_DEST_DIR}/${CMAKE_INSTALL_PREFIX} ${ucx_INSTALL_DIR} SYMBOLIC)
+    file(MAKE_DIRECTORY ${ucx_BINARY_DIR}/install)
+    file(MAKE_DIRECTORY ${ucx_INSTALL_DIR}/include)
+
+    # file(MAKE_DIRECTORY ${ucx_BINARY_DIR}/src)
+
+    include(ExternalProject)
+
+    string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UC)
+
+    # Get the Compiler settings to forward onto autoconf
+    set(COMPILER_SETTINGS
+      "CXX=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}"
+      "CPP=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER} -E"
+      "CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}"
+      "AR=${CMAKE_C_COMPILER_AR}"
+      "RANLIB=${CMAKE_C_COMPILER_RANLIB}"
+      "NM=${CMAKE_NM}"
+      "STRIP=${CMAKE_STRIP}"
+      "CFLAGS=${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}"
+      "CPPFLAGS=${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}"
+      "CXXFLAGS=${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UC}}"
+      "LDFLAGS=${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_${BUILD_TYPE_UC}}"
+    )
+
+    # Use BUILD_IN_SOURCE because UCX cant do out of source builds and CMake sucks at change directory
+    ExternalProject_Add(ucx
+      PREFIX            ${ucx_BINARY_DIR}
+      SOURCE_DIR        ${ucx_BINARY_DIR}
+      INSTALL_DIR       ${ucx_INSTALL_DIR}
+      # Copy from CPM cache into the build tree
+      DOWNLOAD_COMMAND  ${CMAKE_COMMAND} -E copy_directory ${ucx_SOURCE_DIR} ${ucx_BINARY_DIR}
+      # The io_demo fails to build in out of source builds. So remove that from
+      # the Makefile (wish we could just disable all test/examples/apps) as a
+      # part of the download command
+      PATCH_COMMAND     git checkout -- . &&
+                        git apply --whitespace=fix ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches/disable_tools_and_java_binds.patch
+      # Note, we set SED and GREP here since they can be hard coded in the conda libtoolize
+      CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env SED=sed GREP=grep <SOURCE_DIR>/autogen.sh
+                COMMAND <SOURCE_DIR>/contrib/configure-release ${COMPILER_SETTINGS} --prefix=${CMAKE_INSTALL_PREFIX}
+                        --enable-mt --without-rdmacm --disable-gtest --disable-examples
+      BUILD_COMMAND     make -j
+      BUILD_IN_SOURCE   TRUE
+      BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/libuct.a
+                        <INSTALL_DIR>/lib/libucp.a
+                        <INSTALL_DIR>/lib/libucs.a
+                        <INSTALL_DIR>/lib/libucm.a
+      INSTALL_COMMAND   make DESTDIR=${ucx_DEST_DIR} install
+      LOG_CONFIGURE     TRUE
+      LOG_BUILD         TRUE
+      LOG_INSTALL       TRUE
+      # Add a target for configuring to allow for style checks on source code
+      STEP_TARGETS      install
+    )
+
+    # Install only the headers
+    install(
+      DIRECTORY ${ucx_INSTALL_DIR}/include
+      TYPE INCLUDE
+    )
+
+    # TODO: We support components in the custom build branch but not when UCX is found via find_package.
+    # UCT Library
+    add_library(ucx::uct STATIC IMPORTED GLOBAL)
+    set_target_properties(ucx::uct PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ucx_INSTALL_DIR}/include>;$<INSTALL_INTERFACE:include>"
+      INTERFACE_POSITION_INDEPENDENT_CODE "ON"
+    )
+    set_property(TARGET ucx::uct APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+    set_target_properties(ucx::uct PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${ucx_INSTALL_DIR}/lib/libuct.a"
+      IMPORTED_SONAME_RELEASE "libuct.a"
+    )
+    add_dependencies(ucx::uct ucx)
+
+    # UCP Library
+    add_library(ucx::ucp STATIC IMPORTED GLOBAL)
+    set_target_properties(ucx::ucp PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ucx_INSTALL_DIR}/include>;$<INSTALL_INTERFACE:include>"
+      INTERFACE_POSITION_INDEPENDENT_CODE "ON"
+    )
+    set_property(TARGET ucx::ucp APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+    set_target_properties(ucx::ucp PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${ucx_INSTALL_DIR}/lib/libucp.a"
+      IMPORTED_SONAME_RELEASE "libucp.a"
+    )
+    add_dependencies(ucx::ucp ucx)
+
+    # UCS Library
+    add_library(ucx::ucs STATIC IMPORTED GLOBAL)
+    set_target_properties(ucx::ucs PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ucx_INSTALL_DIR}/include>;$<INSTALL_INTERFACE:include>"
+      INTERFACE_POSITION_INDEPENDENT_CODE "ON"
+    )
+    set_property(TARGET ucx::ucs APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+    set_target_properties(ucx::ucs PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${ucx_INSTALL_DIR}/lib/libucs.a"
+      IMPORTED_SONAME_RELEASE "libucs.a"
+    )
+    add_dependencies(ucx::ucs ucx)
+
+    # UCM Library
+    add_library(ucx::ucm STATIC IMPORTED GLOBAL)
+    set_target_properties(ucx::ucm PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ucx_INSTALL_DIR}/include>;$<INSTALL_INTERFACE:include>"
+      INTERFACE_POSITION_INDEPENDENT_CODE "ON"
+    )
+    set_property(TARGET ucx::ucm APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+    set_target_properties(ucx::ucm PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${ucx_INSTALL_DIR}/lib/libucm.a"
+      IMPORTED_SONAME_RELEASE "libucm.a"
+    )
+    add_dependencies(ucx::ucm ucx)
+
+    # Combined ucx::ucx target
+    add_library(ucx::ucx INTERFACE IMPORTED)
+    set_target_properties(ucx::ucx PROPERTIES
+      INTERFACE_LINK_LIBRARIES "ucx::uct;ucx::ucp;ucx::ucs;ucx::ucm"
+    )
+
+    # Finally, add this to the style check dependencies
+    add_dependencies(${PROJECT_NAME}_style_checks ucx-install)
+  else()
+    # Found installed UCX. Make sure to call rapids_export_package without a version.
+    # Otherwise CMake fails with trying to add the dependency twice
+    rapids_export_package(
+      INSTALL ucx ${PROJECT_NAME}-core-exports
+      GLOBAL_TARGETS ucx ucx::ucp ucx::uct ucx_ucx ucx::ucp ucx::uct ucx::ucx
+    )
+
+  endif()
 
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 endfunction()
+
+# function(morpheus_utils_configure_ucx)
+#   list(APPEND CMAKE_MESSAGE_CONTEXT "ucx")
+
+#   set(UCX_VERSION "1.13" CACHE STRING "Version of ucx to use")
+
+#   rapids_find_package(ucx ${UCX_VERSION} REQUIRED
+#     GLOBAL_TARGETS
+#       ucx ucx::ucp ucx::uct ucx_ucx ucx::ucp ucx::uct ucx::ucx
+#     BUILD_EXPORT_SET
+#       ${PROJECT_NAME}-core-exports
+#     INSTALL_EXPORT_SET
+#       ${PROJECT_NAME}-core-exports
+#   )
+
+#   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
+# endfunction()

--- a/cmake/morpheus_utils/python/python_config_macros.cmake
+++ b/cmake/morpheus_utils/python/python_config_macros.cmake
@@ -18,7 +18,7 @@ include_guard(GLOBAL)
 macro(morpheus_utils_python_modules_ensure_python3)
   set(Python3_FIND_VIRTUALENV "FIRST")
   set(Python3_FIND_STRATEGY "LOCATION")
-  find_package(Python3 REQUIRED COMPONENTS Development Development.Module Development.Embed Interpreter NumPy)
+  find_package(Python3 REQUIRED COMPONENTS Development Development.Module Development.Embed Interpreter)
 endmacro()
 
 macro(morpheus_utils_python_modules_ensure_pybind11)


### PR DESCRIPTION
This PR reverts a change in the Boost config to go back to the old method. The following section was found in the old config code:

```cmake
  if (NOT Boost_ADDED)
    # Now add it to the list of packages to install
    rapids_export_package(INSTALL Boost
      ${PROJECT_NAME}-core-exports
      GLOBAL_TARGETS Boost::context Boost::fiber Boost::hana Boost::filesystem Boost::system
    )

    # Overwrite the default package contents
    file(WRITE "${CMAKE_BINARY_DIR}/rapids-cmake/${PROJECT_NAME}-core-exports/install/package_Boost.cmake" "find_dependency(Boost REQUIRED COMPONENTS context fiber filesystem system)")
  endif()
```
It's not immediately clear what this is doing, and its too risky to remove or blindly add back in at this point. Will need to readdress this after release.

MRC Conda build tested locally and working with this PR