### PR TITLE
Use a 32bit build of MatX

### DIFF
--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -22,7 +22,7 @@ function(morpheus_utils_configure_matx)
   list(APPEND CMAKE_MESSAGE_CONTEXT "matx")
 
   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
-  set(MATX_VERSION "0.3.0" CACHE STRING "Version of MatX to use")
+  set(MATX_VERSION "9b5e56a" CACHE STRING "Version of MatX to use")
 
   if(CUDAToolkit_FOUND AND (CUDAToolkit_VERSION VERSION_GREATER "11.5"))
 
@@ -36,7 +36,7 @@ function(morpheus_utils_configure_matx)
         ${PROJECT_NAME}-exports
       CPM_ARGS
         GIT_REPOSITORY  https://github.com/NVIDIA/MatX.git
-        GIT_TAG         "v${MATX_VERSION}"
+        GIT_TAG         "${MATX_VERSION}"
         GIT_SHALLOW     TRUE
         OPTIONS         "MATX_BUILD_32_BIT ON"
                         "MATX_BUILD_BENCHMARKS OFF"

--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -26,6 +26,7 @@ function(morpheus_utils_configure_matx)
 
   if(CUDAToolkit_FOUND AND (CUDAToolkit_VERSION VERSION_GREATER "11.5"))
 
+    # Build MatX with 32 bit indexes, this allows matx size types to match those of cuDF
     rapids_cpm_find(matx ${MATX_VERSION}
       GLOBAL_TARGETS
         matx matx::matx
@@ -37,7 +38,8 @@ function(morpheus_utils_configure_matx)
         GIT_REPOSITORY  https://github.com/NVIDIA/MatX.git
         GIT_TAG         "v${MATX_VERSION}"
         GIT_SHALLOW     TRUE
-        OPTIONS         "MATX_BUILD_BENCHMARKS OFF"
+        OPTIONS         "MATX_BUILD_32_BIT ON"
+                        "MATX_BUILD_BENCHMARKS OFF"
                         "MATX_BUILD_DOCS OFF"
                         "MATX_BUILD_EXAMPLES OFF"
                         "MATX_BUILD_TESTS OFF"

--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -22,7 +22,8 @@ function(morpheus_utils_configure_matx)
   list(APPEND CMAKE_MESSAGE_CONTEXT "matx")
 
   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../ensure_cpm_init.cmake)
-  set(MATX_VERSION "9b5e56a" CACHE STRING "Version of MatX to use")
+  set(MATX_VERSION "0.3.0" CACHE STRING "Version of MatX to use")
+  set(MATX_TAG "9b5e56a" CACHE STRING "Tag of MatX to use")
 
   if(CUDAToolkit_FOUND AND (CUDAToolkit_VERSION VERSION_GREATER "11.5"))
 
@@ -36,7 +37,7 @@ function(morpheus_utils_configure_matx)
         ${PROJECT_NAME}-exports
       CPM_ARGS
         GIT_REPOSITORY  https://github.com/NVIDIA/MatX.git
-        GIT_TAG         "${MATX_VERSION}"
+        GIT_TAG         "${MATX_TAG}"
         GIT_SHALLOW     TRUE
         OPTIONS         "MATX_BUILD_32_BIT ON"
                         "MATX_BUILD_BENCHMARKS OFF"


### PR DESCRIPTION
* Use a 32bit build of MatX to ease interoperability with cuDF (https://github.com/nv-morpheus/Morpheus/issues/684)
* Adopt unreleased fix for 32bit builds of MatX (https://github.com/NVIDIA/MatX/issues/386) 