### PR TITLE
Adding better handling to relative paths for python depfile

### DIFF
--- a/cmake/morpheus_utils/python/pip_gen_depfile.py
+++ b/cmake/morpheus_utils/python/pip_gen_depfile.py
@@ -15,12 +15,32 @@
 
 import argparse
 import os
+import warnings
 
 import pkg_resources as pkg
 from pip._internal.commands.show import search_packages_info
 
 
-def gen_dep_file(pkg_name: str, input_file: str, output_file: str):
+def convert_relative(filename: str, relative_to: str, warn_on_fail=False):
+
+    if (relative_to is None):
+        return filename
+
+    rel_filename = os.path.relpath(filename, start=relative_to)
+
+    if (rel_filename.startswith("..")):
+        if (warn_on_fail):
+            warnings.warn(f"Filename '{filename}' is not relative to {relative_to}. Using absolute path")
+    else:
+        filename = rel_filename
+
+    return filename
+
+
+def gen_dep_file(pkg_name: str, input_file: str, output_file: str, relative_to: str = None):
+
+    # Convert the input file to be relative if specified
+    input_file = convert_relative(input_file, relative_to=relative_to, warn_on_fail=True)
 
     package_generator = search_packages_info([pkg_name])
 
@@ -36,7 +56,10 @@ def gen_dep_file(pkg_name: str, input_file: str, output_file: str):
 
             if (egg_pkg_name == pkg_name):
 
-                joined_files = " ".join([os.path.join(pkg_info.location, f) for f in pkg_info.files])
+                joined_files = "".join([
+                    "\\\n  " + convert_relative(os.path.join(pkg_info.location, f), relative_to=relative_to) + " "
+                    for f in pkg_info.files
+                ])
 
                 # Create the output lines
                 lines = [f"{input_file}: {joined_files}"]
@@ -56,13 +79,20 @@ def gen_dep_file(pkg_name: str, input_file: str, output_file: str):
 if (__name__ == "__main__"):
     parser = argparse.ArgumentParser(description='Process some integers.')
 
-    parser.add_argument("--pkg_name", type=str, required=True, help='an integer for the accumulator')
-    parser.add_argument('--input_file', type=str, required=True, help='sum the integers (default: find the max)')
-    parser.add_argument('--output_file', type=str, help='sum the integers (default: find the max)')
+    parser.add_argument("--pkg_name", type=str, required=True, help='The package name to generate dependencies from')
+    parser.add_argument('--input_file', type=str, required=True, help='The file that will depend on the python package')
+    parser.add_argument('--output_file', type=str, help='The generated output file. Default is `{input_file}.d`')
+    parser.add_argument('--relative_to',
+                        type=str,
+                        default=None,
+                        help='If specified, all files will be relative to this directory')
 
     args = parser.parse_args()
 
     if (args.output_file is None):
         args.output_file = args.input_file + ".d"
 
-    gen_dep_file(pkg_name=args.pkg_name, input_file=args.input_file, output_file=args.output_file)
+    gen_dep_file(pkg_name=args.pkg_name,
+                 input_file=args.input_file,
+                 output_file=args.output_file,
+                 relative_to=args.relative_to)

--- a/cmake/morpheus_utils/python/python_module_tools.cmake
+++ b/cmake/morpheus_utils/python/python_module_tools.cmake
@@ -388,15 +388,21 @@ function(morpheus_utils_build_python_package PACKAGE_NAME)
     set(install_stamp ${sources_binary_dir}/${PYTHON_ACTIVE_PACKAGE_NAME}-install.stamp)
     set(install_stamp_depfile ${install_stamp}.d)
 
+    # Need to set CMP0116 to guarantee absolute/reltive paths in the depfile are handled properly
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0116 NEW)
+
     add_custom_command(
       OUTPUT ${install_stamp}
       COMMAND ${_pip_command}
       COMMAND ${CMAKE_COMMAND} -E touch ${install_stamp}
-      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pip_gen_depfile.py --pkg_name ${PACKAGE_NAME} --input_file ${install_stamp} --output_file ${install_stamp_depfile}
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pip_gen_depfile.py --pkg_name ${PACKAGE_NAME} --input_file ${install_stamp} --output_file ${install_stamp_depfile} --relative_to ${CMAKE_CURRENT_BINARY_DIR}
       DEPENDS ${PYTHON_ACTIVE_PACKAGE_NAME}-outputs
       DEPFILE ${install_stamp_depfile}
       COMMENT "Installing ${PACKAGE_NAME} python package"
     )
+
+    cmake_policy(POP)
 
     add_custom_target(${PYTHON_ACTIVE_PACKAGE_NAME}-install ALL
       DEPENDS ${install_stamp}


### PR DESCRIPTION
Currently, if you have `cmake_minimum_required()` set to `3.20` or lower, then the pip dependency file doesnt work and reinstalls the python package every time. This fix updates the generator to use relative paths and sets the policy to be consistent. 