### PR TITLE
Set default version of MRC to 23.07

### DIFF
--- a/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
+++ b/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
@@ -24,7 +24,7 @@ function(morpheus_utils_configure_mrc)
 
   string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
 
-  set(MRC_VERSION 23.03 CACHE STRING "Which version of MRC to use")
+  set(MRC_VERSION 23.07 CACHE STRING "Which version of MRC to use")
 
   rapids_cpm_find(mrc ${MRC_VERSION}
     GLOBAL_TARGETS


### PR DESCRIPTION
Depends on https://github.com/nv-morpheus/MRC/pull/306 being merged and an alpha package of mrc-23.07 being uploaded to conda

Closes https://github.com/nv-morpheus/utilities/issues/26