### PR TITLE
Make Cython targets have the same extension as pybind11

### DIFF
--- a/cmake/morpheus_utils/python/python_module_tools.cmake
+++ b/cmake/morpheus_utils/python/python_module_tools.cmake
@@ -540,6 +540,9 @@ macro(__create_python_library MODULE_NAME)
     add_cython_target(${MODULE_NAME} "${_ARGS_PYX_FILE}" CXX PY3)
     add_library(${TARGET_NAME} ${lib_type} ${${MODULE_NAME}} ${_ARGS_SOURCE_FILES})
 
+    # Make the filename match pybind
+    pybind11_extension(${TARGET_NAME})
+
     # Need to set -fvisibility=hidden for cython according to https://pybind11.readthedocs.io/en/stable/faq.html
     # set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
   else()


### PR DESCRIPTION
## Description
Small fix to correctly output the right python extension like pybind11 does. Turns this:
```
cudf_helpers.so
```
into
```
cudf_helpers.cpython-310-x86_64-linux-gnu.so
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
