### PR TITLE
Patch matx so that it doesn't fail when LIBCUDACXX_VERSION is empty

### DIFF
--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -34,6 +34,7 @@ function(morpheus_utils_configure_matx)
       INSTALL_EXPORT_SET
       ${PROJECT_NAME}-exports
       CPM_ARGS
+      PATCH_COMMAND   git checkout -- . && git apply --whitespace=fix ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches/matx_libcudacxx_version_fix.patch
       GIT_REPOSITORY https://github.com/NVIDIA/MatX.git
       GIT_TAG "${MATX_TAG}"
       GIT_SHALLOW True

--- a/cmake/morpheus_utils/package_config/matx/patches/matx_libcudacxx_version_fix.patch
+++ b/cmake/morpheus_utils/package_config/matx/patches/matx_libcudacxx_version_fix.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b08c26d..b1b4028 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -100,7 +100,13 @@ endif()
+ 
+ # We typically need newer versions libcudacxx than availabled in the toolkit.  pull down specific version here
+ message(STATUS "Need libcuda++. Finding...")
+-set(LIBCUDACXX_VERSION "2.1.0" CACHE STRING "Version of libcudacxx to use")
++
++# Work around -- sometimes matx ends up getting a LIBCUDACXX_VERSION string that is set, but empty.
++string(STRIP "${LIBCUDACXX_VERSION}" LIBCUDACXX_VERSION_STRIPPED)
++if("${LIBCUDACXX_VERSION_STRIPPED}" STREQUAL "")
++  set(LIBCUDACXX_VERSION "2.1.0" CACHE STRING "Version of libcudacxx to use" FORCE)
++endif()
++
+ include(cmake/FindLibcudacxx.cmake)
+ target_include_directories(matx INTERFACE "$<BUILD_INTERFACE:${LIBCUDACXX_INCLUDE_DIR}>")    
+ 


### PR DESCRIPTION
Sometimes Matx ends up configuring LIBCUDACXX_VERSION as an empty string, which causes it to fail. This patch checks for that condition and ensures that libcudacxx is set to something.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
