### PR TITLE
Revert "Adopt pybind11 v2.10.4 (#45)"

### DIFF
--- a/cmake/morpheus_utils/package_config/pybind11/Configure_pybind11.cmake
+++ b/cmake/morpheus_utils/package_config/pybind11/Configure_pybind11.cmake
@@ -21,9 +21,23 @@ function(morpheus_utils_configure_pybind11)
   list(APPEND CMAKE_MESSAGE_CONTEXT "pybind11")
 
   morpheus_utils_assert_cpm_initialized()
-  set(PYBIND11_VERSION "2.10.4" CACHE STRING "Version of Pybind11 to use")
+  set(PYBIND11_VERSION "2.8.1" CACHE STRING "Version of Pybind11 to use")
 
-  rapids_find_package(pybind11 ${PYBIND11_VERSION} REQUIRED)
+  # Needs a patch to change the internal tracker to use fiber specific storage instead of TSS
+  rapids_cpm_find(pybind11 ${PYBIND11_VERSION}
+    GLOBAL_TARGETS
+      pybind11 pybind11::pybind11
+    BUILD_EXPORT_SET
+      ${PROJECT_NAME}-core-exports
+    INSTALL_EXPORT_SET
+      ${PROJECT_NAME}-core-exports
+    CPM_ARGS
+      GIT_REPOSITORY  https://github.com/pybind/pybind11.git
+      GIT_TAG         "v${PYBIND11_VERSION}"
+      GIT_SHALLOW     TRUE
+      OPTIONS         "PYBIND11_INSTALL ON"
+                      "PYBIND11_TEST OFF"
+  )
 
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 endfunction()


### PR DESCRIPTION

## Description
We will likely need to continue installing pybind11 via CPM in the near future (MRC issue #362). Will create a new PR moving to 2.10.4 via CPM.

This reverts commit b3d13be74c1d5e187162c44b6676b6a9b26e91fb.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
