### PR TITLE
Fix MatX when building MRC and Morpheus in same environment.

### DIFF
--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -26,7 +26,6 @@ function(morpheus_utils_configure_matx)
 
   if(CUDAToolkit_FOUND AND(CUDAToolkit_VERSION VERSION_GREATER "11.5"))
     # Build MatX with 32 bit indexes, this allows matx size types to match those of cuDF
-
     rapids_cpm_find(matx ${MATX_VERSION}
       GLOBAL_TARGETS
       matx matx::matx

--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -26,6 +26,9 @@ function(morpheus_utils_configure_matx)
 
   if(CUDAToolkit_FOUND AND(CUDAToolkit_VERSION VERSION_GREATER "11.5"))
     # Build MatX with 32 bit indexes, this allows matx size types to match those of cuDF
+
+    add_compile_definitions(__STDC_FORMAT_MACROS)
+
     rapids_cpm_find(matx ${MATX_VERSION}
       GLOBAL_TARGETS
       matx matx::matx

--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -27,8 +27,6 @@ function(morpheus_utils_configure_matx)
   if(CUDAToolkit_FOUND AND(CUDAToolkit_VERSION VERSION_GREATER "11.5"))
     # Build MatX with 32 bit indexes, this allows matx size types to match those of cuDF
 
-    add_compile_definitions(__STDC_FORMAT_MACROS)
-
     rapids_cpm_find(matx ${MATX_VERSION}
       GLOBAL_TARGETS
       matx matx::matx
@@ -48,6 +46,8 @@ function(morpheus_utils_configure_matx)
       "MATX_BUILD_TESTS OFF"
       "MATX_INSTALL ON"
     )
+
+    target_compile_definitions(matx INTERFACE __STDC_FORMAT_MACROS)
 
   else()
     message(SEND_ERROR

--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -47,7 +47,7 @@ function(morpheus_utils_configure_matx)
     )
 
     # Explicitly set this compiletime definition because it is not implicitly set when building MRC
-    # and Morphues in the same conda environment For more details, see this github issue...
+    # and Morphues in the same conda environment For more details, see this github pr...
     # https://github.com/nv-morpheus/utilities/pull/55
     target_compile_definitions(matx INTERFACE __STDC_FORMAT_MACROS)
 

--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -46,6 +46,9 @@ function(morpheus_utils_configure_matx)
       "MATX_INSTALL ON"
     )
 
+    # Explicitly set this compiletime definition because it is not implicitly set when building MRC
+    # and Morphues in the same conda environment For more details, see this github issue...
+    # https://github.com/nv-morpheus/utilities/pull/55
     target_compile_definitions(matx INTERFACE __STDC_FORMAT_MACROS)
 
   else()


### PR DESCRIPTION
For unknown reasons, when building MRC and Morpheus within the same conda environment, MatX fails to see some c printf macros. Adding `__STDC_FORMAT_MACROS` fixes the issue, though I'm curious as to why this wasn't a problem before. @mdemoret-nv, is there a better way to fix this?

Contributes to https://github.com/nv-morpheus/Morpheus/issues/704

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
