### PR TITLE
Add helper method for configuring grpc

### DIFF
--- a/cmake/morpheus_utils/package_config/grpc/Configure_grpc.cmake
+++ b/cmake/morpheus_utils/package_config/grpc/Configure_grpc.cmake
@@ -1,0 +1,34 @@
+# =============================================================================
+# SPDX-FileCopyrightText: Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+include_guard(GLOBAL)
+
+function(morpheus_utils_configure_grpc)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "grpc")
+
+  morpheus_utils_assert_cpm_initialized()
+  rapids_find_package(gRPC REQUIRED
+    GLOBAL_TARGETS
+    gRPC::address_sorting gRPC::gpr gRPC::grpc gRPC::grpc_unsecure gRPC::grpc++ gRPC::grpc++_alts gRPC::grpc++_error_details gRPC::grpc++_reflection
+    gRPC::grpc++_unsecure gRPC::grpc_plugin_support gRPC::grpcpp_channelz gRPC::upb gRPC::grpc_cpp_plugin gRPC::grpc_csharp_plugin gRPC::grpc_node_plugin
+    gRPC::grpc_objective_c_plugin gRPC::grpc_php_plugin gRPC::grpc_python_plugin gRPC::grpc_ruby_plugin
+    BUILD_EXPORT_SET ${PROJECT_NAME}-exports
+    INSTALL_EXPORT_SET ${PROJECT_NAME}-exports
+  )
+
+  list(POP_BACK CMAKE_MESSAGE_CONTEXT)
+endfunction()

--- a/cmake/morpheus_utils/package_config/grpc/Configure_grpc.cmake
+++ b/cmake/morpheus_utils/package_config/grpc/Configure_grpc.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# SPDX-FileCopyrightText: Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmake/morpheus_utils/package_config/register_api.cmake
+++ b/cmake/morpheus_utils/package_config/register_api.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# SPDX-FileCopyrightText: Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmake/morpheus_utils/package_config/register_api.cmake
+++ b/cmake/morpheus_utils/package_config/register_api.cmake
@@ -1,4 +1,4 @@
-#=============================================================================
+# =============================================================================
 # SPDX-FileCopyrightText: Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,30 +6,30 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#=============================================================================
+# =============================================================================
 
 include_guard(GLOBAL)
 
 function(morpheus_utils_assert_cpm_initialized)
    get_property(is_cpm_initialized GLOBAL PROPERTY CPM_INITIALIZED)
 
-   if (NOT is_cpm_initialized)
+   if(NOT is_cpm_initialized)
       message(SEND_ERROR "CPM was not initialized before it was used. Ensure morpheus_utils_initialize_cpm() is called from the most root scope")
    endif()
-
 endfunction()
 
 include(${CMAKE_CURRENT_LIST_DIR}/boost/Configure_boost.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cudf/Configure_cudf.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/expected/Configure_expected.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/glog/Configure_glog.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/grpc/Configure_grpc.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/hwloc/Configure_hwloc.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/libcudacxx/Configure_libcudacxx.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/matx/Configure_matx.cmake)


### PR DESCRIPTION
## Description
* Allows Morpheus & MRC to share the same cmake script for configuring gRPC

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
