### PR TITLE
only make triton client depend on zlib in debug builds

### DIFF
--- a/cmake/morpheus_utils/package_config/triton_client/Configure_triton_client.cmake
+++ b/cmake/morpheus_utils/package_config/triton_client/Configure_triton_client.cmake
@@ -54,7 +54,7 @@ function(morpheus_utils_configure_tritonclient)
   # required for debug builds
   target_link_libraries(httpclient_static
     PRIVATE
-      ZLIB::ZLIB
+      $<$<CONFIG:Debug>:ZLIB::ZLIB>
   )
 
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Contributes to https://github.com/nv-morpheus/Morpheus/pull/1468
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
