### PR TITLE
[RELEASE] utilities v24.06.00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# utilities 24.06.00 (02 Jul 2024)
+There are no changes for v24.06.00.
+
 # utilities 24.03.00 (26 Mar 2024)
 
 ## 🚨 Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# utilities 24.06.00 (02 Jul 2024)
+# utilities 24.06.00 (03 Jul 2024)
 There are no changes for v24.06.00.
 
 # utilities 24.03.00 (26 Mar 2024)

--- a/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
+++ b/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
@@ -24,7 +24,7 @@ function(morpheus_utils_configure_mrc)
 
   string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
 
-  set(MRC_VERSION 24.03 CACHE STRING "Which version of MRC to use")
+  set(MRC_VERSION 24.06 CACHE STRING "Which version of MRC to use")
 
   rapids_cpm_find(mrc ${MRC_VERSION}
     GLOBAL_TARGETS


### PR DESCRIPTION
## :snowflake: Code freeze for `branch-24.06` and `v24.06` release

### What does this mean?
Only critical/hotfix level issues should be merged into `branch-24.06` until release (merging of this PR).

All other development PRs should be retargeted towards the next release branch: `branch-24.10`.

### What is the purpose of this PR?
- Update documentation
- Allow testing for the new release
- Enable a means to merge `branch-24.06` into `main` for the release
