### PR TITLE
Move the logic inferring the value of `CMAKE_INSTALL_PREFIX` to it's own function

### DIFF
--- a/cmake/morpheus_utils/environment_config/rapids_cmake/register_api.cmake
+++ b/cmake/morpheus_utils/environment_config/rapids_cmake/register_api.cmake
@@ -73,7 +73,11 @@ function(morpheus_utils_initialize_package_manager
 )
   # Ensure rapids CMake is setup
   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/ensure_rapids_cmake_init.cmake)
+endfunction()
 
+function(morpheus_utils_initialize_install_prefix
+    USE_CONDA_VAR_NAME
+)
   set(USE_CONDA ${${USE_CONDA_VAR_NAME}})
 
   if(USE_CONDA AND DEFINED ENV{CONDA_PREFIX})


### PR DESCRIPTION
## Description
* The `morpheus_utils_initialize_package_manager` needs to be called prior to calling `project`, however the `CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT` isn't defined until after `project` has been called.
* Moves `CMAKE_INSTALL_PREFIX` logic to a new function named `morpheus_utils_initialize_install_prefix`
* This change is needed for nv-morpheus/morpheus#1776

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
