### PR TITLE
Fix in-place Python installs

### DIFF
--- a/cmake/morpheus_utils/python/python_module_tools.cmake
+++ b/cmake/morpheus_utils/python/python_module_tools.cmake
@@ -366,12 +366,9 @@ function(morpheus_utils_build_python_package PACKAGE_NAME)
     list(APPEND _pip_command  "--user")
   endif()
 
-  if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-    list(APPEND _pip_command "-e")
-  endif()
-
   # Change which setup we use if we are using inplace
   if(_ARGS_IS_INPLACE)
+    list(APPEND _pip_command "-e")
     list(APPEND _pip_command "${sources_source_dir}")
   else()
     list(APPEND _pip_command "${sources_binary_dir}")


### PR DESCRIPTION
## Description
* Add the `-e` flag to `pip isntall` based on the `IS_INPLACE` argument rather than the value of the `CMAKE_BUILD_TYPE`

This is needed to resolve nv-morpheus/Morpheus#1923

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
