### PR TITLE
Adopt Rapids 25.02

### DIFF
--- a/cmake/morpheus_utils/package_config/cccl/Configure_cccl.cmake
+++ b/cmake/morpheus_utils/package_config/cccl/Configure_cccl.cmake
@@ -1,4 +1,4 @@
-# =============================================================================
+#=============================================================================
 # SPDX-FileCopyrightText: Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,14 +6,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# =============================================================================
+#=============================================================================
 
 include_guard(GLOBAL)
 
@@ -35,6 +35,7 @@ function(morpheus_utils_configure_cccl)
       ${PROJECT_NAME}-exports
     INSTALL_EXPORT_SET
       ${PROJECT_NAME}-exports
+      # Set to match changes in https://github.com/rapidsai/rapids-cmake/pull/710/files
       GIT_TAG "83028fcdcfa8de51ab359e61ce07198a6003a65e"
       GIT_SHALLOW FALSE
   )

--- a/cmake/morpheus_utils/package_config/cccl/Configure_cccl.cmake
+++ b/cmake/morpheus_utils/package_config/cccl/Configure_cccl.cmake
@@ -1,4 +1,4 @@
-#=============================================================================
+# =============================================================================
 # SPDX-FileCopyrightText: Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -6,14 +6,14 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#=============================================================================
+# =============================================================================
 
 include_guard(GLOBAL)
 
@@ -21,7 +21,7 @@ function(morpheus_utils_configure_cccl)
   list(APPEND CMAKE_MESSAGE_CONTEXT "cccl")
 
   morpheus_utils_assert_cpm_initialized()
-  set(cccl_VERSION "2.5.0" CACHE STRING "Version of cccl to use")
+  set(cccl_VERSION "2.7.0" CACHE STRING "Version of cccl to use")
 
   include("${rapids-cmake-dir}/cpm/cccl.cmake")
 
@@ -35,6 +35,8 @@ function(morpheus_utils_configure_cccl)
       ${PROJECT_NAME}-exports
     INSTALL_EXPORT_SET
       ${PROJECT_NAME}-exports
+      GIT_TAG "83028fcdcfa8de51ab359e61ce07198a6003a65e"
+      GIT_SHALLOW FALSE
   )
 
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
+++ b/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
@@ -1,18 +1,19 @@
-# =============================================================================
+#=============================================================================
 # Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# =============================================================================
+#=============================================================================
+
 
 include_guard(GLOBAL)
 
@@ -35,21 +36,21 @@ function(morpheus_utils_configure_mrc)
     INSTALL_EXPORT_SET
       ${PROJECT_NAME}-exports
     CPM_ARGS
-      GIT_REPOSITORY git@github.com:dagardner-nv/MRC.git # temp using my fork do not merge
-      GIT_TAG david-25.02-x-25.02
-      GIT_SHALLOW FALSE
-      OPTIONS "MRC_BUILD_EXAMPLES OFF"
-    "MRC_BUILD_TESTS OFF"
-    "MRC_BUILD_BENCHMARKS OFF"
-    "MRC_BUILD_PYTHON ON"
-    "MRC_ENABLE_XTENSOR ON"
-    "MRC_ENABLE_MATX ON"
-    "MRC_USE_CONDA ${MORPHEUS_USE_CONDA}"
-    "MRC_USE_CCACHE ${MORPHEUS_USE_CCACHE}"
-    "MRC_USE_CLANG_TIDY ${MORPHEUS_USE_CLANG_TIDY}"
-    "MRC_PYTHON_INPLACE_BUILD OFF"
-    "MRC_PYTHON_PERFORM_INSTALL ON"
-    "MRC_PYTHON_BUILD_STUBS ${${PROJECT_NAME_UPPER}_PYTHON_BUILD_STUBS}"
+      GIT_REPOSITORY  https://github.com/nv-morpheus/MRC.git
+      GIT_TAG         branch-${MRC_VERSION}
+      GIT_SHALLOW     FALSE
+      OPTIONS         "MRC_BUILD_EXAMPLES OFF"
+                      "MRC_BUILD_TESTS OFF"
+                      "MRC_BUILD_BENCHMARKS OFF"
+                      "MRC_BUILD_PYTHON ON"
+                      "MRC_ENABLE_XTENSOR ON"
+                      "MRC_ENABLE_MATX ON"
+                      "MRC_USE_CONDA ${MORPHEUS_USE_CONDA}"
+                      "MRC_USE_CCACHE ${MORPHEUS_USE_CCACHE}"
+                      "MRC_USE_CLANG_TIDY ${MORPHEUS_USE_CLANG_TIDY}"
+                      "MRC_PYTHON_INPLACE_BUILD OFF"
+                      "MRC_PYTHON_PERFORM_INSTALL ON"
+                      "MRC_PYTHON_BUILD_STUBS ${${PROJECT_NAME_UPPER}_PYTHON_BUILD_STUBS}"
   )
 
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
+++ b/cmake/morpheus_utils/package_config/mrc/Configure_mrc.cmake
@@ -1,19 +1,18 @@
-#=============================================================================
+# =============================================================================
 # Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#=============================================================================
-
+# =============================================================================
 
 include_guard(GLOBAL)
 
@@ -36,21 +35,21 @@ function(morpheus_utils_configure_mrc)
     INSTALL_EXPORT_SET
       ${PROJECT_NAME}-exports
     CPM_ARGS
-      GIT_REPOSITORY  https://github.com/nv-morpheus/MRC.git
-      GIT_TAG         branch-${MRC_VERSION}
-      GIT_SHALLOW     FALSE
-      OPTIONS         "MRC_BUILD_EXAMPLES OFF"
-                      "MRC_BUILD_TESTS OFF"
-                      "MRC_BUILD_BENCHMARKS OFF"
-                      "MRC_BUILD_PYTHON ON"
-                      "MRC_ENABLE_XTENSOR ON"
-                      "MRC_ENABLE_MATX ON"
-                      "MRC_USE_CONDA ${MORPHEUS_USE_CONDA}"
-                      "MRC_USE_CCACHE ${MORPHEUS_USE_CCACHE}"
-                      "MRC_USE_CLANG_TIDY ${MORPHEUS_USE_CLANG_TIDY}"
-                      "MRC_PYTHON_INPLACE_BUILD OFF"
-                      "MRC_PYTHON_PERFORM_INSTALL ON"
-                      "MRC_PYTHON_BUILD_STUBS ${${PROJECT_NAME_UPPER}_PYTHON_BUILD_STUBS}"
+      GIT_REPOSITORY git@github.com:dagardner-nv/MRC.git # temp using my fork do not merge
+      GIT_TAG david-25.02-x-25.02
+      GIT_SHALLOW FALSE
+      OPTIONS "MRC_BUILD_EXAMPLES OFF"
+    "MRC_BUILD_TESTS OFF"
+    "MRC_BUILD_BENCHMARKS OFF"
+    "MRC_BUILD_PYTHON ON"
+    "MRC_ENABLE_XTENSOR ON"
+    "MRC_ENABLE_MATX ON"
+    "MRC_USE_CONDA ${MORPHEUS_USE_CONDA}"
+    "MRC_USE_CCACHE ${MORPHEUS_USE_CCACHE}"
+    "MRC_USE_CLANG_TIDY ${MORPHEUS_USE_CLANG_TIDY}"
+    "MRC_PYTHON_INPLACE_BUILD OFF"
+    "MRC_PYTHON_PERFORM_INSTALL ON"
+    "MRC_PYTHON_BUILD_STUBS ${${PROJECT_NAME_UPPER}_PYTHON_BUILD_STUBS}"
   )
 
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)


### PR DESCRIPTION
## Description
* Track cccl v2.7 @ `83028fcdcfa8de51ab359e61ce07198a6003a65e` to match rapidsai/rapids-cmake#710

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
