### PR TITLE
Don't add MatX to the install export set

### DIFF
--- a/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
+++ b/cmake/morpheus_utils/package_config/matx/Configure_matx.cmake
@@ -30,8 +30,6 @@ function(morpheus_utils_configure_matx)
         matx matx::matx
       BUILD_EXPORT_SET
         ${PROJECT_NAME}-exports
-      INSTALL_EXPORT_SET
-        ${PROJECT_NAME}-exports
       CPM_ARGS
         PATCH_COMMAND git checkout -- . && git apply --whitespace=fix ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches/matx_cccl_interface_fix.patch
         GIT_REPOSITORY https://github.com/NVIDIA/MatX.git


### PR DESCRIPTION
lib is header-only and can only be included in .cu files

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
