### PR TITLE
Revert "Update to Rapids 25.06 (#105)"

### DIFF
--- a/cmake/morpheus_utils/environment_config/rapids_cmake/ensure_rapids_cmake_init.cmake
+++ b/cmake/morpheus_utils/environment_config/rapids_cmake/ensure_rapids_cmake_init.cmake
@@ -20,9 +20,7 @@ include_guard(GLOBAL)
 # Ensure we have MORPHEUS_UTILS_RAPIDS_VERSION set
 include(${CMAKE_CURRENT_LIST_DIR}/rapids_version.cmake)
 
-set(RAPIDS_CMAKE_VERSION "${MORPHEUS_UTILS_RAPIDS_VERSION}" CACHE STRING "Version of rapids-cmake to use")
-set(rapids-cmake-version "${MORPHEUS_UTILS_RAPIDS_VERSION}" CACHE STRING "Version of rapids-cmake to use")
-message(STATUS "Using RAPIDS CMake Version: ${RAPIDS_CMAKE_VERSION}")
+set(RAPIDS_CMAKE_VERSION "\${MORPHEUS_UTILS_RAPIDS_VERSION}" CACHE STRING "Version of rapids-cmake to use")
 
 eval_rapids_version(${RAPIDS_CMAKE_VERSION} _rapids_cmake_version)
 


### PR DESCRIPTION
## Description
* Shelving the Rapids 25.06 update for now, as this introduced unforeseen build problems

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
